### PR TITLE
Add voice message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ChatGPT Telegram Bot
 
-This project is a Telegram bot that uses OpenAI's Assistant API to bring ChatGPT to Telegram. It uses the AsyncOpenAI client and aiogram lib
+This project is a Telegram bot that uses OpenAI's Assistant API to bring ChatGPT to Telegram. It uses the AsyncOpenAI client and aiogram lib. Voice messages are transcribed with OpenAI Whisper.
 
 <div align="center">
   <img src="tg.jpg" alt="GPT Bot Image">

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,1 @@
 from . import env
-from . import handlers

--- a/handlers.py
+++ b/handlers.py
@@ -1,4 +1,4 @@
-from aiogram import Router, types
+from aiogram import Router, types, F
 from aiogram.filters import CommandStart, Command
 from .actions import change_assistant, handle_response
 from .client import get_thread, get_assistant, asst_filter
@@ -6,6 +6,7 @@ from .logger import create_logger
 from .translate import _t
 from .helpers import escape_markdown
 from .users import access_middleware
+from .voice import decode_voice
 
 logger = create_logger(__name__)
 router = Router()
@@ -41,6 +42,14 @@ async def on_tutor(message: types.Message) -> None:
 @router.message(asst_filter)
 async def on_change(message: types.Message) -> None:
   await change_assistant(message)
+
+
+@router.message(F.voice)
+async def on_voice(message: types.Message) -> None:
+  text = await decode_voice(message)
+  if text:
+    text_message = message.model_copy(update={"text": text})
+    await handle_response(text_message)
 
 
 @router.message()

--- a/users.py
+++ b/users.py
@@ -87,7 +87,7 @@ async def has_access(message: types.Message):
 async def access_middleware(handler, message: types.Message, data):
   logger.debug(f"middleware:{message}")
 
-  if message.text is None:
+  if message.text is None and message.voice is None:
     logger.debug(f"blocked:message.text={message.text}")
     return
 

--- a/voice.py
+++ b/voice.py
@@ -1,0 +1,19 @@
+from aiogram import types
+from .client import client
+from .logger import create_logger
+
+logger = create_logger(__name__)
+
+
+async def decode_voice(message: types.Message) -> str | None:
+  try:
+    file = await message.bot.download(message.voice.file_id)
+    file.name = "voice.ogg"
+    response = await client.audio.transcriptions.create(
+        model="whisper-1",
+        file=file
+    )
+    return response.text.strip()
+  except Exception as error:
+    logger.error(f"decode_voice:{error}")
+    return None


### PR DESCRIPTION
## Summary
- enable voice message decoding with OpenAI Whisper
- route Telegram voice notes to Whisper decoder
- allow voice messages through access middleware
- avoid side effects in package import
- document voice support in README

## Testing
- `pytest -q test.py` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_6843f6a4e588832f8fafea533971f027