### PR TITLE
Add GPT‑4.1 mode selection

### DIFF
--- a/messages.py
+++ b/messages.py
@@ -6,6 +6,8 @@ messages = {
             "welcome": "Hi, {name}!\n```{id}```",
             "new_chat": "`Context cleared`",
             "new_tutor": "Select new Assistant:\n{tutors}",
+            "new_mode": "Select mode:",
+            "your_mode": "Mode: `{mode}`",
             "error_in_the_code": "`error 42`"
         },
         "gpt": {
@@ -19,6 +21,8 @@ messages = {
             "welcome": "Привет, {name}!\n```{id}```",
             "new_chat": "`История очищена`",
             "new_tutor": "Выберите нового Ассистента:\n{tutors}",
+            "new_mode": "Выберите режим:",
+            "your_mode": "Режим: `{mode}`",
             "error_in_the_code": "`ошибка 42`"
         },
         "gpt": {

--- a/modes.py
+++ b/modes.py
@@ -1,0 +1,41 @@
+import yaml
+from pathlib import Path
+from aiogram import types
+from .logger import create_logger
+
+logger = create_logger(__name__)
+
+storage = Path(__file__).parent / "modes.yaml"
+user_modes = {}
+
+
+def load():
+    try:
+        with open(storage, 'r') as file:
+            return yaml.safe_load(file) or {}
+    except FileNotFoundError:
+        return {}
+
+
+def save():
+    with open(storage, 'w') as file:
+        yaml.dump(user_modes, file, allow_unicode=True)
+
+
+async def get_mode(user_id=None, new_mode=None):
+    if not user_modes:
+        user_modes.update(load())
+
+    if user_id is None:
+        return user_modes
+
+    if new_mode:
+        user_modes[user_id] = new_mode
+        save()
+        return new_mode
+
+    return user_modes.get(user_id, "assistant")
+
+
+def mode_filter(message: types.Message):
+    return message.text in ["assistant", "gpt-4.1"]


### PR DESCRIPTION
## Summary
- add new `modes.py` to store user mode preference
- allow choosing between Assistant API and GPT‑4.1 model
- update handlers to expose /mode command and handle mode changes
- extend actions to process GPT‑4.1 requests
- update translations with new strings

## Testing
- `pip install pytest pytest-asyncio freezegun`
- `pip install PyYAML==6.0.1`
- `pip install aiogram>=3.4.0`
- `pytest -vv test.py`

------
https://chatgpt.com/codex/tasks/task_e_6843faf6123c832fbb235c8d9ec0a95e