### PR TITLE
Add clear chat command and o4-mini-high model

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -17,6 +17,7 @@ from .modes import get_mode
 logger = create_logger(__name__)
 
 GPT4_MODEL = "gpt-4.1"
+O4_MINI_MODEL = "o4-mini-high"
 model_history = {}
 
 
@@ -141,8 +142,12 @@ async def add_messages_to_thread(thread: beta.Thread, messages: List[types.Messa
 async def process_model_message(user_id: int, message: types.Message):
   history = model_history.setdefault(user_id, [])
   history.append({"role": "user", "content": message.text})
+
+  mode = await get_mode(user_id)
+  model = GPT4_MODEL if mode == "gpt-4.1" else O4_MINI_MODEL
+
   response = await client.chat.completions.create(
-      model=GPT4_MODEL,
+      model=model,
       messages=history,
   )
   reply = response.choices[0].message.content

--- a/handlers.py
+++ b/handlers.py
@@ -77,6 +77,13 @@ async def on_new(message: types.Message) -> None:
     clear_history(message.from_user.id)
 
 
+@router.message(Command("clear"))
+async def on_clear(message: types.Message) -> None:
+  await message.answer(_t("bot.new_chat"))
+  await get_thread(message.from_user.id, new_thread=True)
+  clear_history(message.from_user.id)
+
+
 @router.message(Command("tutor"))
 async def on_tutor(message: types.Message) -> None:
   tutors = await get_assistant()
@@ -92,7 +99,7 @@ async def on_tutor(message: types.Message) -> None:
 
 @router.message(Command("mode"))
 async def on_mode(message: types.Message) -> None:
-  modes = ["assistant", "gpt-4.1"]
+  modes = ["assistant", "gpt-4.1", "o4-mini-high"]
   await message.answer(
       _t("bot.new_mode"),
       reply_markup=types.ReplyKeyboardMarkup(

--- a/modes.py
+++ b/modes.py
@@ -38,4 +38,4 @@ async def get_mode(user_id=None, new_mode=None):
 
 
 def mode_filter(message: types.Message):
-    return message.text in ["assistant", "gpt-4.1"]
+    return message.text in ["assistant", "gpt-4.1", "o4-mini-high"]


### PR DESCRIPTION
## Summary
- add `/clear` command that resets the assistant thread and model chat history
- support new `o4-mini-high` model option

## Testing
- `pytest -vv test.py`

------
https://chatgpt.com/codex/tasks/task_e_684511784440832fa740d326a40105bd